### PR TITLE
Формулировки 56 и 57

### DIFF
--- a/exam/spring_exam_keys.qmd
+++ b/exam/spring_exam_keys.qmd
@@ -571,7 +571,7 @@ format:
     $$
     \begin{aligned}
     r(x) &= \lambda \|x\|_1, \quad \lambda > 0 \\
-    [\text{prox}_r(x)]_i &= [|x_i - \lambda]_+ \cdot \text{sign}(x_i)
+    [\text{prox}_r(x)]_i &= [|x_i| - \lambda]_+ \cdot \text{sign}(x_i)
     \end{aligned}
     $$
     :::
@@ -580,7 +580,7 @@ format:
     :::{.callout-tip appearance="simple"}
     $$
     \begin{aligned}
-    r(x) &= \frac{\mu}{2} \|x\|_2^2\\
+    r(x) &= \frac{\mu}{2} \|x\|_2^2, \quad \mu > 0\\
     \text{prox}_r(x) &= \frac{x}{1 + \mu}
     \end{aligned}
     $$


### PR DESCRIPTION
В 56 не был закрыт модуль x, в 57 добавил mu > 0